### PR TITLE
Infer content type for S3 from blob

### DIFF
--- a/app/models/active_storage/blob.rb
+++ b/app/models/active_storage/blob.rb
@@ -216,7 +216,7 @@ class ActiveStorage::Blob < ActiveRecord::Base
     self.checksum  = compute_checksum_in_chunks(io)
     self.byte_size = io.size
 
-    service.upload(key, io, checksum: checksum)
+    service.upload(key, io, checksum: checksum, content_type: content_type)
   end
 
   # Downloads the file associated with this blob. If no block is given, the entire file is read into memory and returned.

--- a/lib/active_storage/service/azure_storage_service.rb
+++ b/lib/active_storage/service/azure_storage_service.rb
@@ -18,7 +18,7 @@ module ActiveStorage
       @path = path
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         begin
           blobs.create_block_blob(container, key, io, content_md5: checksum)

--- a/lib/active_storage/service/disk_service.rb
+++ b/lib/active_storage/service/disk_service.rb
@@ -15,7 +15,7 @@ module ActiveStorage
       @root = root
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         IO.copy_stream(io, make_path_for(key))
         ensure_integrity_of(key, checksum) if checksum

--- a/lib/active_storage/service/gcs_service.rb
+++ b/lib/active_storage/service/gcs_service.rb
@@ -13,7 +13,7 @@ module ActiveStorage
       @config = config
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       instrument :upload, key: key, checksum: checksum do
         begin
           # The official GCS client library doesn't allow us to create a file with no Content-Type metadata.

--- a/lib/active_storage/service/mirror_service.rb
+++ b/lib/active_storage/service/mirror_service.rb
@@ -24,7 +24,7 @@ module ActiveStorage
 
     # Upload the +io+ to the +key+ specified to all services. If a +checksum+ is provided, all services will
     # ensure a match when the upload has completed or raise an ActiveStorage::IntegrityError.
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, **)
       each_service.collect do |service|
         service.upload key, io.tap(&:rewind), checksum: checksum
       end

--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -19,7 +19,9 @@ module ActiveStorage
     def upload(key, io, checksum: nil)
       instrument :upload, key: key, checksum: checksum do
         begin
-          object_for(key).put(upload_options.merge(body: io, content_md5: checksum))
+          object_for(key).put(upload_options.merge(
+            body: io, content_md5: checksum, content_type: io.content_type
+          ))
         rescue Aws::S3::Errors::BadDigest
           raise ActiveStorage::IntegrityError
         end

--- a/lib/active_storage/service/s3_service.rb
+++ b/lib/active_storage/service/s3_service.rb
@@ -16,11 +16,12 @@ module ActiveStorage
       @upload_options = upload
     end
 
-    def upload(key, io, checksum: nil)
+    def upload(key, io, checksum: nil, content_type: nil)
+      content_type = content_type || io.try(:content_type)
       instrument :upload, key: key, checksum: checksum do
         begin
           object_for(key).put(upload_options.merge(
-            body: io, content_md5: checksum, content_type: io.content_type
+            body: io, content_md5: checksum, content_type: content_type
           ))
         rescue Aws::S3::Errors::BadDigest
           raise ActiveStorage::IntegrityError


### PR DESCRIPTION
Problem: any svg file attached via activestorage is shown as broken everywhere on the website.
[Imgix documentation](https://support.imgix.com/hc/en-us/articles/360000977386-Can-I-render-SVG-files-with-imgix-) says that 
> SVG files should also contain the image/svg+xml Content-Type value in their response headers.

To pass that header to imgix, we have to set it as metadata on the file uploaded to S3. This change sets Content-Type metadata property for every uploaded image, inferring it directly from the blob passed to ActiveStorage.
